### PR TITLE
Suspend cluster-api-ipam-provider-in-cluster App CR for HelmRelease migration

### DIFF
--- a/kustomize/cluster-api-ipam-provider-in-cluster.yaml
+++ b/kustomize/cluster-api-ipam-provider-in-cluster.yaml
@@ -3,6 +3,7 @@ kind: App
 metadata:
   annotations:
     chart-operator.giantswarm.io/force-helm-upgrade: "true"
+    app-operator.giantswarm.io/paused: "true"
   labels:
     app-operator.giantswarm.io/version: 0.0.0
   name: cluster-api-ipam-provider-in-cluster


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/35076