### PR TITLE
Suspend cluster-api-cleaner-vsphere App CR for HelmRelease migration

### DIFF
--- a/kustomize/cluster-api-cleaner-vsphere.yaml
+++ b/kustomize/cluster-api-cleaner-vsphere.yaml
@@ -3,6 +3,7 @@ kind: App
 metadata:
   annotations:
     chart-operator.giantswarm.io/force-helm-upgrade: "true"
+    app-operator.giantswarm.io/paused: "true"
   labels:
     app-operator.giantswarm.io/version: 0.0.0
   name: cluster-api-cleaner-vsphere


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/35076